### PR TITLE
convert net23 to esm

### DIFF
--- a/net23/package.json
+++ b/net23/package.json
@@ -3,7 +3,7 @@
   "description": "Network 23",
   "license": "GPL-3.0-only",
   "version": "0.1.0",
-  "type": "commonjs",
+  "type": "module",
   "private": true,
   "repository": {
     "type": "git",
@@ -12,6 +12,7 @@
   "scripts": {
     "local": "serverless offline --reloadHandler",
     "build": "serverless package",
+    "bundle": "esbuild --platform=node --bundle src/handler.js > dist/handler.cjs",
     "deploy": "serverless deploy --force",
     "justdeploy": "serverless deploy --force --package .serverless",
     "stowaway": "node stowaway.mjs",

--- a/net23/persephone/persephone.js
+++ b/net23/persephone/persephone.js
@@ -1,21 +1,11 @@
+import { Sticker, getAccess, log, look, Size, Data } from 'icarus'
 //here's where you require all the node modules
 //code here can use library functions
 //lambdas can call in to functions here
 //but library code can't use functions here
 //so that is the order of things
 
-let module_icarus
-async function loadIcarus() { if (!module_icarus) module_icarus = await import('icarus'); return module_icarus }//icarus is ESM, so you have to await a dynamic import into this CommonJS module
-
-let module_amazonEmail, module_amazonText, module_twilio, module_sendgrid//this project is CommonJS so that we can use require with node modules that may expect that classic styling
-function loadAmazonEmail() { if (!module_amazonEmail) module_amazonEmail = require('@aws-sdk/client-ses'); return module_amazonEmail }
-function loadAmazonTexts() { if (!module_amazonText)  module_amazonText  = require('@aws-sdk/client-sns'); return module_amazonText  }
-function loadTwilio()      { if (!module_twilio)      module_twilio      = require('twilio');              return module_twilio      }
-function loadSendgrid()    { if (!module_sendgrid)    module_sendgrid    = require('@sendgrid/mail');      return module_sendgrid    }
-
-async function requireModules() {
-	let { Sticker, getAccess, log, look, Size, Data } = await loadIcarus()
-
+export async function requireModules() {
 	let cut = 512
 	let o = {}
 	try {
@@ -65,8 +55,6 @@ async function requireModules() {
 	return o
 }
 
-module.exports = { loadIcarus, requireModules }
-
 
 
 
@@ -87,12 +75,12 @@ module.exports = { loadIcarus, requireModules }
 
 
 
-//                       _ _                   _                     
-//   ___ _ __ ___   __ _(_) |   __ _ _ __   __| |  ___ _ __ ___  ___ 
+//                       _ _                   _
+//   ___ _ __ ___   __ _(_) |   __ _ _ __   __| |  ___ _ __ ___  ___
 //  / _ \ '_ ` _ \ / _` | | |  / _` | '_ \ / _` | / __| '_ ` _ \/ __|
 // |  __/ | | | | | (_| | | | | (_| | | | | (_| | \__ \ | | | | \__ \
 //  \___|_| |_| |_|\__,_|_|_|  \__,_|_| |_|\__,_| |___/_| |_| |_|___/
-//                                                                   
+//
 
 async function sendEmail_useAmazon(c) {
 
@@ -235,7 +223,7 @@ And wisdom to know the difference.
 
 
 
-async function snippet() {
+export async function snippet() {
 	return 'turned off twilio snippet as that is moving to persophne'
 	/*
 	let twilio = await loadTwilio()
@@ -265,7 +253,7 @@ and check datadog, amazon, and twilio dashboards throughout!
 
 
 //let's test this stuff with node on the command line
-async function snippet2(card) {
+export async function snippet2(card) {
 	log('hi from snippet')
 	log(look(card))
 

--- a/net23/serverless.yml
+++ b/net23/serverless.yml
@@ -19,42 +19,42 @@ provider:
 # #### FOR API FUNCTIONS ####
 functions:
   ping5:
-    handler: src/ping5.handler #paths to distribution for upload after rollup
+    handler: dist/handler.ping5 #paths to distribution for upload after rollup
     timeout: 30 #let a Lambda run for 30 seconds, up from default 3 second limit, maximum possible is 15 minutes
     events:
       - http:
           path: ping5
           method: get #GET so you can check it with a regular browser
   test:
-    handler: src/test.handler
+    handler: dist/handler.test
     timeout: 30
     events:
       - http:
           path: test
           method: get
   snippet:
-    handler: src/snippet.handler
+    handler: dist/handler.snippet
     timeout: 30
     events:
       - http:
           path: snippet
           method: get
   snippet2:
-    handler: src/snippet2.handler
+    handler: dist/handler.snippet2
     timeout: 30
     events:
       - http:
           path: snippet2
           method: get
   snippet3:
-    handler: src/snippet3.handler
+    handler: dist/handler.snippet3
     timeout: 30
     events:
       - http:
           path: snippet3
           method: get
   door:
-    handler: src/door.handler
+    handler: dist/handler.door
     timeout: 30
     events:
       - http:

--- a/net23/src/door.js
+++ b/net23/src/door.js
@@ -1,9 +1,7 @@
+import { doorLambda } from 'icarus';
 
-const { loadIcarus } = require('../persephone/persephone.js');
-
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler (lambdaEvent, lambdaContext) {
 	try {
-		let { doorLambda } = await loadIcarus()
 		return doorLambda({lambdaEvent, lambdaContext, doorProcessBelow})
 	} catch (e) { console.error('[OUTER]', e) }
 	return { statusCode: 500, headers: { 'Content-Type': 'application/json' }, body: null }

--- a/net23/src/handler.js
+++ b/net23/src/handler.js
@@ -1,0 +1,6 @@
+export { default as door } from './door.js';
+export { default as ping5 } from './ping5.js';
+export { default as test } from './test.js';
+export { default as snippet } from './snippet.js';
+export { default as snippet2 } from './snippet2.js';
+export { default as snippet3 } from './snippet3.js';

--- a/net23/src/ping5.js
+++ b/net23/src/ping5.js
@@ -1,11 +1,8 @@
+import { Sticker } from 'icarus'
 
-const { loadIcarus } = require('../persephone/persephone.js');
-
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler(lambdaEvent, lambdaContext) {
 	let note = ''
 	try {
-		let { Sticker } = await loadIcarus()
-
 		note = `lambda says: ${Sticker().all}, ping5done`
 
 	} catch (e) { note = 'ping5 lambda error: '+e.stack }

--- a/net23/src/snippet.js
+++ b/net23/src/snippet.js
@@ -1,11 +1,9 @@
+import { Sticker } from 'icarus';
+import { snippet } from '../persephone/persephone.js';
 
-const { loadIcarus } = require('../persephone/persephone.js');
-
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler (lambdaEvent, lambdaContext) {
 	let o = {}
 	try {
-		let { Sticker, snippet } = await loadIcarus()
-
 		o.note = `lambda snippet says: ${Sticker().all}, v2024oct21c`
 		o.look = await snippet()
 

--- a/net23/src/snippet2.js
+++ b/net23/src/snippet2.js
@@ -1,9 +1,9 @@
 
-const { loadIcarus, requireModules } = require('../persephone/persephone.js');
+import { doorLambda, Sticker, runTests, defined } from 'icarus';
+import { requireModules } from '../persephone/persephone.js';
 
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler (lambdaEvent, lambdaContext) {
 	try {
-		let { doorLambda } = await loadIcarus()
 		return doorLambda({lambdaEvent, lambdaContext, doorProcessBelow})
 	} catch (e) { console.error('[OUTER]', e) }
 	return { statusCode: 500, headers: { 'Content-Type': 'application/json' }, body: null }
@@ -11,8 +11,6 @@ exports.handler = async (lambdaEvent, lambdaContext) => {
 async function doorProcessBelow(door) {
 	let response = {}
 	try {
-		let { Sticker, runTests, defined } = await loadIcarus()
-
 		response.message = 'hi from net23 snippet2, using door and require!'
 		response.sticker = Sticker().all
 		response.version = defined(process) ? process.version : 'process not defined'

--- a/net23/src/snippet3.js
+++ b/net23/src/snippet3.js
@@ -1,20 +1,15 @@
 
-const { loadIcarus } = require('../persephone/persephone.js');
+import { log, look, Now, Tag, Data, Sticker, doorLambda } from 'icarus';
+import { snippet } from '../persephone/persephone.js';
 
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler (lambdaEvent, lambdaContext) {
 	try {
-		let { doorLambda } = await loadIcarus()
 		return doorLambda({lambdaEvent, lambdaContext, doorProcessBelow})
 	} catch (e) { console.error('[OUTER]', e) }
 	return { statusCode: 500, headers: { 'Content-Type': 'application/json' }, body: null }
 }
 async function doorProcessBelow(door) {
 	let o = {}
-	let {
-		log, look, Now, Tag, Data,
-		Sticker, snippet,
-		doorLambda,
-	} = await loadIcarus()
 
 //	await snippetBelow()
 	o.note = `lambda snippet3 says: ${Sticker().all}`

--- a/net23/src/test.js
+++ b/net23/src/test.js
@@ -1,11 +1,8 @@
+import { Sticker, runTests } from 'icarus';
 
-const { loadIcarus } = require('../persephone/persephone.js');
-
-exports.handler = async (lambdaEvent, lambdaContext) => {
+export default async function handler (lambdaEvent, lambdaContext) {
 	let note = ''
 	try {
-		let { Sticker, runTests } = await loadIcarus()
-
 		note = `lambda says: ${(await runTests()).message}, ${Sticker().all}`
 
 	} catch (e) { note = 'ping test lambda error: '+e.stack }


### PR DESCRIPTION
the trick to fix the issue I was having on the call was just to rename the output to `dist/handler.cjs` to denote commonjs.

I made a handlers.js file that imports the other handlers to make it easier to bundle a single file, but it would also be possible to use `xargs` on the esbuild command if you wanted to bundle each separately. (I'm not sure there's a benefit to doing that)